### PR TITLE
Fix relative date logic

### DIFF
--- a/src/components/GoalFeed.jsx
+++ b/src/components/GoalFeed.jsx
@@ -81,14 +81,14 @@ const GoalFeed = ({ goal, isOpen, onClose }) => {
     const date = new Date(dateString)
     const now = new Date()
     const diffTime = Math.abs(now - date)
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 1) return 'Today'
-    if (diffDays === 2) return 'Yesterday'
-    if (diffDays <= 7) return `${diffDays - 1} days ago`
-    
-    return date.toLocaleDateString('en-US', { 
-      month: 'short', 
+    if (diffDays === 0) return 'Today'
+    if (diffDays === 1) return 'Yesterday'
+    if (diffDays < 7) return `${diffDays} days ago`
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
       day: 'numeric',
       year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
     })

--- a/src/components/PublicGoalFeed.jsx
+++ b/src/components/PublicGoalFeed.jsx
@@ -89,14 +89,14 @@ const PublicGoalFeed = () => {
     const date = new Date(dateString)
     const now = new Date()
     const diffTime = Math.abs(now - date)
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 1) return 'Today'
-    if (diffDays === 2) return 'Yesterday'
-    if (diffDays <= 7) return `${diffDays - 1} days ago`
-    
-    return date.toLocaleDateString('en-US', { 
-      month: 'short', 
+    if (diffDays === 0) return 'Today'
+    if (diffDays === 1) return 'Yesterday'
+    if (diffDays < 7) return `${diffDays} days ago`
+
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
       day: 'numeric',
       year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined
     })

--- a/src/pages/TrackingScreen.jsx
+++ b/src/pages/TrackingScreen.jsx
@@ -420,11 +420,11 @@ const TrackingScreen = ({ onBack }) => {
     const date = new Date(dateString)
     const now = new Date()
     const diffTime = Math.abs(now - date)
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 
-    if (diffDays === 1) return t.today
-    if (diffDays === 2) return t.yesterday
-    if (diffDays <= 7) return `${diffDays - 1} ${t.daysAgo}`
+    if (diffDays === 0) return t.today
+    if (diffDays === 1) return t.yesterday
+    if (diffDays < 7) return `${diffDays} ${t.daysAgo}`
     
     return date.toLocaleDateString('en-US', { 
       month: 'short', 


### PR DESCRIPTION
## Summary
- fix relative date calculations in the goal feed, public feed and tracking screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857dfc765908324addc23b6bd9f2467