### PR TITLE
Fix tracking screen layout

### DIFF
--- a/src/components/UnifiedTrackingButton.jsx
+++ b/src/components/UnifiedTrackingButton.jsx
@@ -368,7 +368,7 @@ const UnifiedTrackingButton = ({
         className="absolute inset-0 pointer-events-none z-20"
       >
         {/* Up - Camera */}
-        <div className={`absolute -top-8 left-1/2 transform -translate-x-1/2 transition-all duration-300 ${
+        <div className={`absolute -top-16 left-1/2 transform -translate-x-1/2 transition-all duration-300 ${
           gestureDirection === 'up' ? 'scale-125 text-primary-500' : 'text-gray-400'
         }`}>
           <div className="p-4 bg-white/90 backdrop-blur-sm rounded-full shadow-premium">
@@ -377,7 +377,7 @@ const UnifiedTrackingButton = ({
         </div>
 
         {/* Right - Complete */}
-        <div className={`absolute top-1/2 -right-8 transform -translate-y-1/2 transition-all duration-300 ${
+        <div className={`absolute top-1/2 -right-16 transform -translate-y-1/2 transition-all duration-300 ${
           gestureDirection === 'right' ? 'scale-125 text-success-500' : 'text-gray-400'
         }`}>
           <div className="p-4 bg-white/90 backdrop-blur-sm rounded-full shadow-premium">
@@ -386,7 +386,7 @@ const UnifiedTrackingButton = ({
         </div>
 
         {/* Left - Not Done */}
-        <div className={`absolute top-1/2 -left-8 transform -translate-y-1/2 transition-all duration-300 ${
+        <div className={`absolute top-1/2 -left-16 transform -translate-y-1/2 transition-all duration-300 ${
           gestureDirection === 'left' ? 'scale-125 text-error-500' : 'text-gray-400'
         }`}>
           <div className="p-4 bg-white/90 backdrop-blur-sm rounded-full shadow-premium">

--- a/src/pages/TrackingScreen.jsx
+++ b/src/pages/TrackingScreen.jsx
@@ -735,7 +735,7 @@ const TrackingScreen = ({ onBack }) => {
       <div 
         {...feedDragHandler()}
         ref={feedRef}
-        className="relative z-10 bg-white/60 backdrop-blur-xl rounded-t-2xl sm:rounded-t-3xl shadow-premium-xl min-h-screen pt-8 px-4 sm:px-6 lg:px-8 pb-24 sm:pb-32"
+        className="relative z-10 bg-white/60 backdrop-blur-xl rounded-t-2xl sm:rounded-t-3xl shadow-premium-xl min-h-screen pt-12 sm:pt-16 px-4 sm:px-6 lg:px-8 pb-24 sm:pb-32"
         style={{ touchAction: 'pan-y' }}
       >
         <div className="max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary
- move gesture icons further from the tracking button so they appear outside
- add more padding between the tracking button and the feed

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e036d7288324b1f7c020c473fc5a