### PR TITLE
Fix goal deletion logic

### DIFF
--- a/src/components/GoalSlider.jsx
+++ b/src/components/GoalSlider.jsx
@@ -102,10 +102,13 @@ const GoalSlider = ({ selectedGoalId, onGoalSelect, refreshTrigger }) => {
   }
 
   const handleGoalDeleted = (deletedGoalId) => {
-    setGoals(prev => prev.filter(g => g.id !== deletedGoalId))
-    if (selectedGoalId === deletedGoalId) {
-      onGoalSelect(goals.length > 1 ? goals.find(g => g.id !== deletedGoalId)?.id : null)
-    }
+    setGoals(prev => {
+      const updated = prev.filter(g => g.id !== deletedGoalId)
+      if (selectedGoalId === deletedGoalId) {
+        onGoalSelect(updated.length ? updated[0].id : null)
+      }
+      return updated
+    })
     setShowEditModal(false)
     setEditingGoal(null)
   }


### PR DESCRIPTION
## Summary
- update GoalSlider's `handleGoalDeleted` so filtered list is computed first

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6857e47801208324be2aa8afceb76108